### PR TITLE
updated powershell bug in funtion Get-EC2InstanceMetadata

### DIFF
--- a/doc_source/ec2-windows-volumes.md
+++ b/doc_source/ec2-windows-volumes.md
@@ -67,7 +67,7 @@ Try {
 	$InstanceId = Get-EC2InstanceMetadata "meta-data/instance-id"
 	$AZ = Get-EC2InstanceMetadata "meta-data/placement/availability-zone"
 	$Region = $AZ.Remove($AZ.Length - 1)
-	$BlockDeviceMappings = (Get-EC2Instance -Region $Region -Instance $InstanceId).Instances.BlockDeviceMappings
+	$BlockDeviceMappings = (Get-EC2InstanceMetadata -Region $Region -Instance $InstanceId).Instances.BlockDeviceMappings
 	$VirtualDeviceMap = @{}
 	(Get-EC2InstanceMetadata "meta-data/block-device-mapping").Split("`n") | ForEach-Object {
 		$VirtualDevice = $_


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The function that you are calling is wrong code will fail to get block device mappings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
