### PR TITLE
Removed typo in windows-ami-guidelines.md

### DIFF
--- a/doc_source/windows-amis-guidelines.md
+++ b/doc_source/windows-amis-guidelines.md
@@ -5,7 +5,7 @@ Use the following guidelines to reduce the attack surface and improve the reliab
 + Develop a repeatable process for building, updating, and republishing AMIs\.
 + Build AMIs using the most up\-to\-date operating systems, packages, and software\.
 + [Download](https://s3.amazonaws.com/ec2-downloads-windows/EC2Config/EC2Install.zip) and install the latest version of the EC2Config service\. For more information about installing this service, see [Installing the Latest Version of EC2Config](UsingConfig_Install.md)\. 
-+ Verify that Ec2SetPassword, Ec2WindowsActiviate and Ec2HandleUserData are enabled\.
++ Verify that Ec2SetPassword, Ec2WindowsActivate and Ec2HandleUserData are enabled\.
 + Verify that no guest accounts or Remote Desktop user accounts are present\.
 + Disable or remove unnecessary services and programs to reduce the attack surface of your AMI\.
 + Remove instance credentials, such as your key pair, from the AMI \(if you saved them on the AMI\)\. Store the credentials in a safe location\.


### PR DESCRIPTION
Changed Ec2WindowsActiviate on the fifth bullet point to Ec2WindowsActivate as per config.xml in EC2 Config Service directory

*Issue #, if available:* N/A

*Description of changes:* Removed superfluous 'i' in Ec2WindowsActivate


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
