### PR TITLE
Add support for 5th generation instances within ec2-windows-volumes powershell script

### DIFF
--- a/doc_source/ec2-windows-volumes.md
+++ b/doc_source/ec2-windows-volumes.md
@@ -45,73 +45,87 @@ The following PowerShell script lists each disk and its corresponding device nam
 ```
 # List the Windows disks
 
-function Get-EC2InstanceMetadata
-{
-	param([string]$Path)
-	(Invoke-WebRequest -Uri "http://169.254.169.254/latest/$Path").Content 
+function Get-EC2InstanceMetadata {
+  param([string]$Path)
+  (Invoke-WebRequest -Uri "http://169.254.169.254/latest/$Path").Content 
 }
 
-function Convert-SCSITargetIdToDeviceName
-{
-    param([int]$SCSITargetId)
-	If ($SCSITargetId -eq 0) {
-		return "/dev/sda1"
-	}
-	$deviceName = "xvd"
-	If ($SCSITargetId -gt 25) {
-		$deviceName += [char](0x60 + [int]($SCSITargetId / 26))
-	}
-	$deviceName += [char](0x61 + $SCSITargetId % 26)
-	return $deviceName
+function Convert-SCSITargetIdToDeviceName {
+  param([int]$SCSITargetId)
+  If ($SCSITargetId -eq 0) {
+    return "sda1"
+  }
+  $deviceName = "xvd"
+  If ($SCSITargetId -gt 25) {
+    $deviceName += [char](0x60 + [int]($SCSITargetId / 26))
+  }
+  $deviceName += [char](0x61 + $SCSITargetId % 26)
+  return $deviceName
 }
 
 Try {
-	$InstanceId = Get-EC2InstanceMetadata "meta-data/instance-id"
-	$AZ = Get-EC2InstanceMetadata "meta-data/placement/availability-zone"
-	$Region = $AZ.Remove($AZ.Length - 1)
-	$BlockDeviceMappings = (Get-EC2Instance -Region $Region -Instance $InstanceId).Instances.BlockDeviceMappings
-	$VirtualDeviceMap = @{}
-	(Get-EC2InstanceMetadata "meta-data/block-device-mapping").Split("`n") | ForEach-Object {
-		$VirtualDevice = $_
-		$BlockDeviceName = Get-EC2InstanceMetadata "meta-data/block-device-mapping/$VirtualDevice"
-		$VirtualDeviceMap[$BlockDeviceName] = $VirtualDevice
-		$VirtualDeviceMap[$VirtualDevice] = $BlockDeviceName
-	}
+  $InstanceId = Get-EC2InstanceMetadata "meta-data/instance-id"
+  $AZ = Get-EC2InstanceMetadata "meta-data/placement/availability-zone"
+  $Region = $AZ.Remove($AZ.Length - 1)
+  $BlockDeviceMappings = (Get-EC2Instance -Region $Region -Instance $InstanceId).Instances.BlockDeviceMappings
+  $VirtualDeviceMap = @{}
+  (Get-EC2InstanceMetadata "meta-data/block-device-mapping").Split("`n") | ForEach-Object {
+    $VirtualDevice = $_
+    $BlockDeviceName = Get-EC2InstanceMetadata "meta-data/block-device-mapping/$VirtualDevice"
+    $VirtualDeviceMap[$BlockDeviceName] = $VirtualDevice
+    $VirtualDeviceMap[$VirtualDevice] = $BlockDeviceName
+  }
 }
 Catch {
-	Write-Host "Could not access the AWS API, therefore, VolumeId is not available. 
-	Verify that you provided your access keys." -ForegroundColor Yellow
+  Write-Host "Could not access the AWS API, therefore, VolumeId is not available. 
+Verify that you provided your access keys." -ForegroundColor Yellow
 }
 
-Get-WmiObject -Class Win32_DiskDrive | ForEach-Object {
-    $DiskDrive = $_
-	$Volumes = Get-WmiObject -Query "ASSOCIATORS OF {Win32_DiskDrive.DeviceID='$($DiskDrive.DeviceID)'} WHERE AssocClass=Win32_DiskDriveToDiskPartition" | ForEach-Object {
-		$DiskPartition = $_
-		Get-WmiObject -Query "ASSOCIATORS OF {Win32_DiskPartition.DeviceID='$($DiskPartition.DeviceID)'} WHERE AssocClass=Win32_LogicalDiskToPartition"
-	}
-	If ($DiskDrive.PNPDeviceID -like "*PROD_PVDISK*") {
-		$BlockDeviceName = Convert-SCSITargetIdToDeviceName($DiskDrive.SCSITargetId)
-		$BlockDevice = $BlockDeviceMappings | Where-Object { $_.DeviceName -eq $BlockDeviceName }
-		$VirtualDevice = If ($VirtualDeviceMap.ContainsKey($BlockDeviceName)) { $VirtualDeviceMap[$BlockDeviceName] } Else { $null }
-	} ElseIf ($DiskDrive.PNPDeviceID -like "*PROD_AMAZON_EC2_NVME*") {
-		$BlockDeviceName = Get-EC2InstanceMetadata "meta-data/block-device-mapping/ephemeral$($DiskDrive.SCSIPort - 2)"
-		$BlockDevice = $null
-		$VirtualDevice = If ($VirtualDeviceMap.ContainsKey($BlockDeviceName)) { $VirtualDeviceMap[$BlockDeviceName] } Else { $null }
-	} Else {
-		$BlockDeviceName = $null
-		$BlockDevice = $null
-		$VirtualDevice = $null
-	}
-	New-Object PSObject -Property @{
-		Disk = $DiskDrive.Index;
-		Partitions = $DiskDrive.Partitions;
-		DriveLetter = If ($Volumes -eq $null) { "N/A" } Else { $Volumes.DeviceID };
-		EbsVolumeId = If ($BlockDevice -eq $null) { "N/A" } Else { $BlockDevice.Ebs.VolumeId };
-		Device = If ($BlockDeviceName -eq $null) { "N/A" } Else { $BlockDeviceName };
-		VirtualDevice = If ($VirtualDevice -eq $null) { "N/A" } Else { $VirtualDevice };
-		VolumeName = If ($Volumes -eq $null) { "N/A" } Else { $Volumes.VolumeName };
-	}
-} | Sort-Object Disk | Format-Table -AutoSize -Property Disk, Partitions, DriveLetter, EbsVolumeId, Device, VirtualDevice, VolumeName
+Get-disk | ForEach-Object {
+  $DiskDrive = $_
+  $Disk = $_.Number
+  $Partitions = $_.NumberOfPartitions
+  $EbsVolumeID = $_.SerialNumber -replace "_[^ ]*$" -replace "vol", "vol-"
+  Get-Partition -DiskId $_.Path | ForEach-Object {
+    if ($_.DriveLetter -ne "") {
+      $DriveLetter = $_.DriveLetter
+      $VolumeName = (Get-PSDrive | Where-Object {$_.Name -eq $DriveLetter}).Description
+    }
+  } 
+
+  If ($DiskDrive.path -like "*PROD_PVDISK*") {
+    $BlockDeviceName = Convert-SCSITargetIdToDeviceName((Get-WmiObject -Class Win32_Diskdrive | Where-Object {$_.DeviceID -eq ("\\.\PHYSICALDRIVE" + $DiskDrive.Number) }).SCSITargetId)
+    $BlockDeviceName = "/dev/" + $BlockDeviceName
+    $BlockDevice = $BlockDeviceMappings | Where-Object { $_.DeviceName -eq ($BlockDeviceName) }
+    $EbsVolumeID = $BlockDevice.Ebs.VolumeId 
+    $VirtualDevice = If ($VirtualDeviceMap.ContainsKey($BlockDeviceName)) { $VirtualDeviceMap[$BlockDeviceName] } Else { $null }
+  }
+  ElseIf ($DiskDrive.path -like "*PROD_AMAZON_EC2_NVME*") {
+    $BlockDeviceName = Get-EC2InstanceMetadata "meta-data/block-device-mapping/ephemeral$((Get-WmiObject -Class Win32_Diskdrive | Where-Object {$_.DeviceID -eq ("\\.\PHYSICALDRIVE"+$DiskDrive.Number) }).SCSIPort - 2)"
+    $BlockDevice = $null
+    $VirtualDevice = If ($VirtualDeviceMap.ContainsKey($BlockDeviceName)) { $VirtualDeviceMap[$BlockDeviceName] } Else { $null }
+  }
+  ElseIf ($DiskDrive.path -like "*PROD_AMAZON*") {
+    $BlockDevice = ""
+    $BlockDeviceName = ($BlockDeviceMappings | Where-Object {$_.ebs.VolumeId -eq $EbsVolumeID}).DeviceName
+    $VirtualDevice = $null
+  }
+  Else {
+    $BlockDeviceName = $null
+    $BlockDevice = $null
+    $VirtualDevice = $null
+  }
+  New-Object PSObject -Property @{
+    Disk          = $Disk;
+    Partitions    = $Partitions;
+    DriveLetter   = If ($DriveLetter -eq $null) { "N/A" } Else { $DriveLetter };
+    EbsVolumeId   = If ($EbsVolumeID -eq $null) { "N/A" } Else { $EbsVolumeID };
+    Device        = If ($BlockDeviceName -eq $null) { "N/A" } Else { $BlockDeviceName };
+    VirtualDevice = If ($VirtualDevice -eq $null) { "N/A" } Else { $VirtualDevice };
+    VolumeName    = If ($VolumeName -eq $null) { "N/A" } Else { $VolumeName };
+    AWSVolumeName = If ($BlockDevice -eq $null) { "N/A" } Else { (Get-EC2Volume -VolumeId $EbsVolumeID).Tags.Value };
+  }
+} | Sort-Object Disk | Format-Table -AutoSize -Property Disk, Partitions, DriveLetter, EbsVolumeId, Device, VirtualDevice, VolumeName, AWSVolumeName
 ```
 
 **Note**  

--- a/doc_source/ec2-windows-volumes.md
+++ b/doc_source/ec2-windows-volumes.md
@@ -123,9 +123,8 @@ Get-disk | ForEach-Object {
     Device        = If ($BlockDeviceName -eq $null) { "N/A" } Else { $BlockDeviceName };
     VirtualDevice = If ($VirtualDevice -eq $null) { "N/A" } Else { $VirtualDevice };
     VolumeName    = If ($VolumeName -eq $null) { "N/A" } Else { $VolumeName };
-    AWSVolumeName = If ($BlockDevice -eq $null) { "N/A" } Else { (Get-EC2Volume -VolumeId $EbsVolumeID).Tags.Value };
   }
-} | Sort-Object Disk | Format-Table -AutoSize -Property Disk, Partitions, DriveLetter, EbsVolumeId, Device, VirtualDevice, VolumeName, AWSVolumeName
+} | Sort-Object Disk | Format-Table -AutoSize -Property Disk, Partitions, DriveLetter, EbsVolumeId, Device, VirtualDevice, VolumeName
 ```
 
 **Note**  

--- a/doc_source/ec2-windows-volumes.md
+++ b/doc_source/ec2-windows-volumes.md
@@ -96,7 +96,7 @@ Get-disk | ForEach-Object {
   If ($DiskDrive.path -like "*PROD_PVDISK*") {
     $BlockDeviceName = Convert-SCSITargetIdToDeviceName((Get-WmiObject -Class Win32_Diskdrive | Where-Object {$_.DeviceID -eq ("\\.\PHYSICALDRIVE" + $DiskDrive.Number) }).SCSITargetId)
     $BlockDeviceName = "/dev/" + $BlockDeviceName
-    $BlockDevice = $BlockDeviceMappings | Where-Object { $_.DeviceName -eq ($BlockDeviceName) }
+    $BlockDevice = $BlockDeviceMappings | Where-Object { $BlockDeviceName -like "*"+$_.DeviceName+"*" }
     $EbsVolumeID = $BlockDevice.Ebs.VolumeId 
     $VirtualDevice = If ($VirtualDeviceMap.ContainsKey($BlockDeviceName)) { $VirtualDeviceMap[$BlockDeviceName] } Else { $null }
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to 5th generation instances (C5, R5 as example) using NVME drives, the current PowerShell script gives back no useful responses. 

I've rewritten the script to use Get-Disk instead of Get-WMIObject wherever possible and of course, support NVME volumes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
