### PR TITLE
Update Upgrading_PV_drivers.md

### DIFF
--- a/doc_source/Upgrading_PV_drivers.md
+++ b/doc_source/Upgrading_PV_drivers.md
@@ -22,7 +22,7 @@ Be sure to check the `readme.txt` file in the download for system requirements\.
 
 ## Upgrade Windows Server instances \(AWS PV upgrade\)<a name="aws-pv-upgrade"></a>
 
-Use the following procedure to perform an in\-place upgrade of AWS PV drivers, or to upgrade from Citrix PV drivers to AWS PV drivers on Windows Server 2008 R2, Windows Server 2012, Windows Server 2012 R2,Windows Server 2016, or Windows Server 2019\. This upgrade is not available for RedHat drivers, or for other versions of Windows Server\.
+Use the following procedure to perform an in\-place upgrade of AWS PV drivers, or to upgrade from Citrix PV drivers to AWS PV drivers on Windows Server 2008 R2, Windows Server 2012, Windows Server 2012 R2, Windows Server 2016, Windows Server 2019, or Windows Server 2022\. This upgrade is not available for RedHat drivers, or for other versions of Windows Server\.
 
 **Important**  
 If your instance is a domain controller, see [Upgrade a domain controller \(AWS PV upgrade\)](#aws-pv-upgrade-dc)\. The upgrade process for domain controller instances is different than standard editions of Windows\. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I've added Windows Server 2022 to the list of windows server versions in the "Upgrade Windows Server instances (AWS PV upgrade)" section. This is assuming that the steps to upgrade AWS PV is the same for Windows Server 2022 as it is for the other listed server versions. I saw no indication elsewhere to indicate that there is a separate process for upgrading Windows Server 2022 and this article (https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/xen-drivers-overview.html) mentions that Windows Server 2022 should be running latest AWS PV.

I also inserted a missing space between Windows Server 2012 R2 and Windows Server 2016 in the list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
